### PR TITLE
Support removing multiple relations when programmable-multiple is broken

### DIFF
--- a/contrib/bind/provider.py
+++ b/contrib/bind/provider.py
@@ -32,7 +32,17 @@ class Provider(object):
 
     def remove_record(self, record, domain='example.com'):
         zp = ZoneParser(domain)
-        zp.zone.remove('alias', record['rr'], record['alias'])
+        if type(record) is dict:
+            zp.zone.remove('alias', record['rr'], record['alias'])
+        elif type(record) is list:
+            for item in record:
+                rcrd = item.split(' ')
+                try:
+                    zp.zone.remove('alias', rcrd[3], rcrd[0])
+                except KeyError as e:
+                    # skip removals if we dont find the data. log it and move on
+                    print "Unable to locate {}".format(rcrd[0])
+
         zp.save()
         self.reload_config()
 

--- a/hooks/programmable-multiple-relation-departed
+++ b/hooks/programmable-multiple-relation-departed
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.environ['CHARM_DIR'],
+                                                    'contrib')))
+
+#from bind.provider import BindProvider
+
+from charmhelpers.core.hookenv import (
+    log,
+    config,
+    unit_get,
+    relation_get,
+)
+
+from common import trim_empty_array_elements as trim
+from common import load_class
+
+class ProgrammableDeparted(object):
+
+    def __init__(self):
+        self.config = config()
+        self.remove_record()
+
+
+    def remove_record(self):
+        if not relation_get('resources'):
+            log('No resources sent on the wire, unable to update DNS.',
+                    level='CRITICAL')
+            log('Manual cleanup of records will be required!',
+                    level='CRITICAL')
+            return
+
+        resources = trim(relation_get('resources').split('\n'))
+
+        domain = config()['domain']
+
+        class_string = "{}.provider.Provider".format(self.config['provider'])
+        provider = load_class(class_string)
+        p = provider()
+        p.remove_record(resources, domain)
+
+if __name__ == '__main__':
+    c = ProgrammableDeparted()


### PR DESCRIPTION
This can be kind of militant, and in order to make it idempotent I left
it be at catching key errors, and allowing the execution to continue
processing. This may yield instances where a record is removed
accidentally and probably warrants further investigation.
