### PR TITLE
Update A records with changes, rather than overwriting them

### DIFF
--- a/contrib/bind/zone.py
+++ b/contrib/bind/zone.py
@@ -27,9 +27,6 @@ class Zone(object):
         if not value:
             return self.contents['A']
         else:
-            idx = self.find(self.contents['A'], 'alias', value['alias'])
-            if idx != -1:
-                self.contents['A'].pop(idx)
             self.contents['A'].append(value)
             return self.contents['A']
 


### PR DESCRIPTION
This fixes #3 - I've tested it live.

This change doesn't make it possible for clients to choose whether they should overwrite or update a record - partly because I wasn't sure what a sensible API would be, and partly to be consistent with AAAA records (where changes always trigger an update).

Do you think offering this choice is necessary (or will it just be irrelevant once https://github.com/chuckbutler/DNS-Charm/issues/8 is fixed, and deleted nodes remove themselves)? If you do, what do you think the API should be?
